### PR TITLE
Fatal Step

### DIFF
--- a/toast-tk-dao-api/src/main/java/com/synaptix/toast/dao/domain/impl/test/block/ITestPage.java
+++ b/toast-tk-dao-api/src/main/java/com/synaptix/toast/dao/domain/impl/test/block/ITestPage.java
@@ -53,4 +53,8 @@ public interface ITestPage extends ITaggable, IBlock {
 	public boolean isSuccess();
 
 	void setIsSuccess(boolean isSuccess);
+
+	void setIsFatal(boolean isFatal);
+
+	boolean isFatal();
 }

--- a/toast-tk-dao/src/main/java/com/synaptix/toast/dao/domain/impl/test/block/TestPage.java
+++ b/toast-tk-dao/src/main/java/com/synaptix/toast/dao/domain/impl/test/block/TestPage.java
@@ -46,6 +46,8 @@ public class TestPage extends BasicEntityBean implements IRunnableTest, ITestPag
 
 	private boolean isSuccess;
 
+	private boolean isFatal;
+
     public TestPage() {
     	this.blocks = new ArrayList<>();
     }
@@ -190,4 +192,15 @@ public class TestPage extends BasicEntityBean implements IRunnableTest, ITestPag
             boolean isSuccess) {
         this.isSuccess = isSuccess;
     }
+
+    @Override
+    public void setIsFatal(
+            boolean isFatal) {
+        this.isFatal = isFatal;
+    }
+
+	@Override
+	public boolean isFatal() {
+		return this.isFatal;
+	}
 }

--- a/toast-tk-dao/src/main/java/com/synaptix/toast/dao/service/dao/access/test/TestPageFromProxy.java
+++ b/toast-tk-dao/src/main/java/com/synaptix/toast/dao/service/dao/access/test/TestPageFromProxy.java
@@ -16,6 +16,7 @@ public class TestPageFromProxy {
 		page.setBlocks(testPage.getBlocks());
 		page.setId(testPage.getIdAsString());
 		page.setIsSuccess(testPage.isSuccess());
+		page.setIsFatal(testPage.isFatal());
 		page.setPreviousIsSuccess(testPage.isPreviousIsSuccess());
 		page.setParsingErrorMessage(testPage.getParsingErrorMessage());
 		page.setPreviousExecutionTime(testPage.getPreviousExecutionTime());

--- a/toast-tk-runtime-api/src/main/java/com/synaptix/toast/runtime/block/FatalExcecutionException.java
+++ b/toast-tk-runtime-api/src/main/java/com/synaptix/toast/runtime/block/FatalExcecutionException.java
@@ -1,0 +1,20 @@
+package com.synaptix.toast.runtime.block;
+
+public class FatalExcecutionException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public FatalExcecutionException() {}  
+
+	public FatalExcecutionException(String message) {  
+		super(message); 
+	}  
+
+	public FatalExcecutionException(Throwable cause) {  
+		super(cause); 
+	}  
+
+	public FatalExcecutionException(String message, Throwable cause) {  
+		super(message, cause); 
+	} 
+}

--- a/toast-tk-runtime-api/src/main/java/com/synaptix/toast/runtime/block/IBlockRunner.java
+++ b/toast-tk-runtime-api/src/main/java/com/synaptix/toast/runtime/block/IBlockRunner.java
@@ -5,7 +5,7 @@ import com.synaptix.toast.dao.domain.impl.test.block.IBlock;
 
 public interface IBlockRunner<E extends IBlock> {
 	
-	public void run(E block) throws IllegalAccessException, ClassNotFoundException;
+	public void run(E block) throws IllegalAccessException, ClassNotFoundException, FatalExcecutionException;
 
 	public void setInjector(Injector injector);
 

--- a/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/AbstractScenarioRunner.java
+++ b/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/AbstractScenarioRunner.java
@@ -40,8 +40,7 @@ public abstract class AbstractScenarioRunner extends AbstractRunner {
         EventBus eventBus = injector.getInstance(Key.get(EventBus.class, EngineEventBus.class));
         this.progressReporter = new DefaultTestProgressReporter(eventBus, htmlReportGenerator);
     }
-    
-    
+
     protected AbstractScenarioRunner(Module m) {
     	super(m);
         this.htmlReportGenerator = injector.getInstance(IHTMLReportGenerator.class);
@@ -49,7 +48,6 @@ public abstract class AbstractScenarioRunner extends AbstractRunner {
         this.progressReporter = new DefaultTestProgressReporter(eventBus, htmlReportGenerator);
     }
 
-    
     protected AbstractScenarioRunner() {
     	super();
         this.htmlReportGenerator = injector.getInstance(IHTMLReportGenerator.class);

--- a/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/bean/TestLineDescriptor.java
+++ b/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/bean/TestLineDescriptor.java
@@ -78,7 +78,7 @@ public class TestLineDescriptor {
 	}
 
 	public boolean isFailFatalCommand() {
-		return testLineAction.startsWith("* ");
+		return testLineAction.startsWith("! ");
 	}
 
 	public String getActionImpl() {

--- a/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/block/TestBlockRunner.java
+++ b/toast-tk-runtime/src/main/java/com/synaptix/toast/runtime/block/TestBlockRunner.java
@@ -52,20 +52,24 @@ public class TestBlockRunner implements IBlockRunner<TestBlock> {
 	private List<FixtureService> fixtureApiServices;
 
 	@Override
-	public void run(TestBlock block) throws IllegalAccessException, ClassNotFoundException {
+	public void run(TestBlock block) throws IllegalAccessException, ClassNotFoundException, FatalExcecutionException{
 		for (TestLine line : block.getBlockLines()) {
-			long startTime = System.currentTimeMillis();
-			TestLineDescriptor descriptor = new TestLineDescriptor(block, line);
-			TestResult result = invokeActionAdapterAction(descriptor);
-			line.setExcutionTime(System.currentTimeMillis() - startTime);
+			TestResult result = getResultForLine(block, line);
 			if (result.isFatal()) {
-//				Désactivation issue #54
-//				throw new IllegalAccessException(
-//						"Test execution stopped, due to fail fatal error: " + line + " - Failed !");
+				throw new FatalExcecutionException();
 			}
-			finaliseResultKind(line, result);
-			line.setTestResult(result);
 		}
+	}
+
+	private TestResult getResultForLine(TestBlock block, TestLine line)
+			throws IllegalAccessException, ClassNotFoundException {
+		long startTime = System.currentTimeMillis();
+		TestLineDescriptor descriptor = new TestLineDescriptor(block, line);
+		TestResult result = invokeActionAdapterAction(descriptor);
+		line.setExcutionTime(System.currentTimeMillis() - startTime);
+		finaliseResultKind(line, result);
+		line.setTestResult(result);
+		return result;
 	}
 
 	private void finaliseResultKind(TestLine line, ITestResult result) {


### PR DESCRIPTION
Vérifier que l’exécution s'arrête bien dans le cas d’échec d’exécution sur une étape dite fatale
Remplacer l'étoile par un autre symbole, par exemple `!`
