### PR TITLE
Fix NullPointerException when no extraModules is defined 

### DIFF
--- a/toast-tk-runtime/src/main/java/io/toast/tk/runtime/AbstractRunner.java
+++ b/toast-tk-runtime/src/main/java/io/toast/tk/runtime/AbstractRunner.java
@@ -50,8 +50,10 @@ public abstract class AbstractRunner {
 			@Override
 			protected void configure() {
 				install(new EngineModule());
-				for(Module module: extraModules){
-					install(module);
+				if (extraModules != null) {
+					for (Module module : extraModules) {
+						install(module);
+					}
 				}
 				listAvailableServicesByReflection.forEach(f -> bindActionAdapter(f.clazz));
 			}


### PR DESCRIPTION
(when running tests from maven plugin)

```
1 error
        at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
        at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
        at com.google.inject.Guice.createInjector(Guice.java:99)
        at com.google.inject.Guice.createInjector(Guice.java:73)
        at com.google.inject.Guice.createInjector(Guice.java:62)
        at io.toast.tk.runtime.AbstractRunner.<init>(AbstractRunner.java:49)
        at io.toast.tk.runtime.AbstractTestPlanRunner.<init>(AbstractTestPlanRunner.java:61)
        at io.toast.tk.runtime.AbstractTestPlanRunner.<init>(AbstractTestPlanRunner.java:47)
        at io.toast.tk.maven.plugin.run.TestPlanRunner.<init>(TestPlanRunner.java:15)
        at io.toast.tk.maven.plugin.RunTestPlanMojo.run(RunTestPlanMojo.java:102)
        at io.toast.tk.maven.plugin.RunTestPlanMojo.lambda$execute$1(RunTestPlanMojo.java:91)
        at java.util.ArrayList.forEach(ArrayList.java:1249)
        at io.toast.tk.maven.plugin.RunTestPlanMojo.execute(RunTestPlanMojo.java:89)
        at io.toast.tk.maven.plugin.RunTestPlanMojo.execute(RunTestPlanMojo.java:65)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.NullPointerException
        at io.toast.tk.runtime.AbstractRunner$2.configure(AbstractRunner.java:53)
        at com.google.inject.AbstractModule.configure(AbstractModule.java:62)
        at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
        at com.google.inject.spi.Elements.getElements(Elements.java:110)
        at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
        ... 34 more
```